### PR TITLE
Fixed handling command including white space. (eg: CONFIG GET)

### DIFF
--- a/lib/RedisDB.pm
+++ b/lib/RedisDB.pm
@@ -324,7 +324,7 @@ sub send_command {
     # and reconnect if not
     $self->_recv_data_nb;
 
-    my $request = $self->{_parser}->build_request( $command, @_ );
+    my $request = $self->{_parser}->build_request( (split /\s+/, $command), @_ );
     defined $self->{_socket}->send($request) or confess "Can't send request to server: $!";
     $self->{_parser}->add_callback($callback);
     return 1;

--- a/t/redis_commands.t
+++ b/t/redis_commands.t
@@ -167,6 +167,10 @@ sub cmd_server {
     ok( ( $1 and $2 ), "Looks like a version" );
     my $version = 0 + $1 + 0.001 * $2 + ( $3 ? 0.000001 * $3 : 0 );
     is '' . $redis->version, "$version", "Correct server version: $version";
+
+    if ($redis->version >= 2.0) {
+        eq_or_diff $redis->config_get("loglevel"), [qw(loglevel notice)], "CONFIG GET";
+    }
 }
 
 sub cmd_sets {


### PR DESCRIPTION
RedisDB#config_get cause error.

```
$redis->config_get('maxmemory'); => ERR unknown command 'CONFIG GET'
```

RedisDB 1.03 send following data to redis-server:

```
*2
$10
CONFIG GET
$9
maxmemory
```

But redis-server expected is:

```
*3
$6
CONFIG
$3
GET
$9
maxmemory
```
