### PR TITLE
Change host:port splits to allow for Redis IPv6 format

### DIFF
--- a/lib/RedisDB.pm
+++ b/lib/RedisDB.pm
@@ -989,7 +989,7 @@ sub _parse_cluster_nodes {
         my ( $node_id, $addr, $flags, $master_id, $ping, $pong, $state, @slots ) =
           split / /;
         my %flags = map { $_ => 1 } split /,/, $flags;
-        my ( $host, $port ) = split /:/, $addr;
+        my ( $host, $port ) = split /:([^:]+)$/, $addr;
         unless ($host) {
             $host = $self->{host}, $addr = "$self->{host}:$port",
         }

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -258,7 +258,7 @@ sub execute {
     while ( $attempts-- ) {
         my $redis = $self->{_connections}{$node_key};
         unless ($redis) {
-            my ( $host, $port ) = split /:/, $node_key;
+            my ( $host, $port ) = split /:([^:]+)$/, $node_key;
             $redis = _connect_to_node(
                 $self,
                 {
@@ -546,7 +546,7 @@ sub _get_node_info {
 sub _ensure_hash_address {
     my $addr = shift;
     unless ( ref $addr eq 'HASH' ) {
-        my ( $host, $port ) = split /:/, $addr;
+        my ( $host, $port ) = split /:([^:]+)$/, $addr;
         croak "invalid address spec: $addr" unless $host and $port;
         $addr = {
             host => $host,


### PR DESCRIPTION
Redis IPv6 host:port uses the unfortunate format of `2001:db8:a:b:1:2:3:4:5678`.  The old code did not split IPv6 addresses properly.  The updated code should be IPv4/IPv6 agnostic, since it splits on the final colon rather than the first.