### PR TITLE
Subsecond timeout on read/write.

### DIFF
--- a/lib/RedisDB.pm
+++ b/lib/RedisDB.pm
@@ -373,7 +373,8 @@ sub _connect {
             }
         }
         else {
-            $timeout = pack( 'L!L!', $self->{timeout}, 0 );
+            $timeout = pack( 'L!L!', $self->{timeout},
+				($self->{timeout} * 1000000) % 1000000 );
         }
         try {
             defined $self->{_socket}->sockopt( SO_RCVTIMEO, $timeout )


### PR DESCRIPTION
Currently if you use a timeout value less than 1, then it appears to work for connect operations. 
However read operations hang forever.  This is because the microsecond part of the struct timeval
is left at zero. 

This patch fixes that for Linux (and perhaps other OS's other than the BSDs which have separate
code paths).

I can supply patches for the other cases too, but have no way of testing them.