### PR TITLE
Forwarding params to cluster

### DIFF
--- a/lib/RedisDB.pm
+++ b/lib/RedisDB.pm
@@ -2,7 +2,7 @@ package RedisDB;
 
 use strict;
 use warnings;
-our $VERSION = "2.54";
+our $VERSION = "2.56";
 $VERSION = eval $VERSION;
 
 use RedisDB::Error;

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -160,13 +160,6 @@ will retrieve information about all cluster nodes and slots mappings.
 
 Password, if redis server requires authentication.
 
-=item database
-
-DB number to use. Specified database will be selected immediately after
-connecting to the server. Database changes when you sending I<select> command
-to the server. You can get current database using I<selected_database> method.
-Default value is 0.
-
 =back
 
 =cut

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -2,7 +2,7 @@ package RedisDB::Cluster;
 
 use strict;
 use warnings;
-our $VERSION = "2.55";
+our $VERSION = "2.56";
 $VERSION = eval $VERSION;
 
 use Carp;

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -614,7 +614,7 @@ sub _connect_to_node {
             host        => $node->{host},
             port        => $node->{port},
             raise_error => 0,
-            %{$self->{_param},
+            %{$self->{_param}},
         );
         $self->{_connections}{$host_key} = $redis->{_socket} ? $redis : undef;
     }

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -178,7 +178,6 @@ sub new {
         _connections => {},
         _nodes       => $params{startup_nodes},
         _password    => $params{password},
-        _database    => $params{database} || 0,
     };
     $self->{no_slots_initialization} = 1 if $params{no_slots_initialization};
 
@@ -630,7 +629,6 @@ sub _connect_to_node {
             port        => $node->{port},
             raise_error => 0,
             password    => $self->{_password},
-            database    => $self->{_database},
         );
         $self->{_connections}{$host_key} = $redis->{_socket} ? $redis : undef;
     }

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -153,17 +153,32 @@ contain 'host' and 'port' elements. Constructor will try to connect to nodes
 from the list and from the first node to which it will be able to connect it
 will retrieve information about all cluster nodes and slots mappings.
 
+=over 4
+
+=item password
+
+Password, if redis server requires authentication.
+
+=item database
+
+DB number to use. Specified database will be selected immediately after
+connecting to the server. Database changes when you sending I<select> command
+to the server. You can get current database using I<selected_database> method.
+Default value is 0.
+
+=back
+
 =cut
 
 sub new {
     my ( $class, %params ) = @_;
 
-    my $startup_nodes = delete $params{startup_nodes};
     my $self = {
         _slots       => [],
         _connections => {},
-        _nodes       => $startup_nodes,
-        _params      => \%params,
+        _nodes       => $params{startup_nodes},
+        _password    => $params{password},
+        _database    => $params{database} || 0,
     };
     $self->{no_slots_initialization} = 1 if $params{no_slots_initialization};
 
@@ -614,7 +629,8 @@ sub _connect_to_node {
             host        => $node->{host},
             port        => $node->{port},
             raise_error => 0,
-            %{$self->{_params}},
+            password    => $self->{_password},
+            database    => $self->{_database},
         );
         $self->{_connections}{$host_key} = $redis->{_socket} ? $redis : undef;
     }

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -188,7 +188,7 @@ sub _initialize_slots {
         next unless $redis;
 
         my $nodes = $redis->cluster_nodes;
-        next if ref $nodes =~ /^RedisDB::Error/;
+        next if ref ($nodes) =~ /^RedisDB::Error/;
         $new_nodes = $nodes;
         for (@$nodes) {
             $new_nodes{"$_->{host}:$_->{port}"}++;

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -163,7 +163,7 @@ sub new {
         _slots       => [],
         _connections => {},
         _nodes       => $startup_nodes,
-        _params      => \%params;
+        _params      => \%params,
     };
     $self->{no_slots_initialization} = 1 if $params{no_slots_initialization};
 

--- a/lib/RedisDB/Cluster.pm
+++ b/lib/RedisDB/Cluster.pm
@@ -614,7 +614,7 @@ sub _connect_to_node {
             host        => $node->{host},
             port        => $node->{port},
             raise_error => 0,
-            %{$self->{_param}},
+            %{$self->{_params}},
         );
         $self->{_connections}{$host_key} = $redis->{_socket} ? $redis : undef;
     }


### PR DESCRIPTION

1. Redis cluster not connected if Redis with password. 
2. Code not forwarding params from redis cluster to connect redis (add "password" and "database" params)
3. Update pod
Fix error
next if ref $nodes =~ /^RedisDB::Error/; - not work
Please update module on cpan